### PR TITLE
Add typing speed selector with optional custom delay

### DIFF
--- a/main.go
+++ b/main.go
@@ -716,13 +716,13 @@ func main() {
 
 	customMsEntry := widget.NewEntry()
 	customMsEntry.SetPlaceHolder("ms per char")
-	customMsEntry.Disable() // only enabled when Custom is selected
+	customMsEntry.Hide() // start hidden unless Custom is selected
 
 	speedSelect.OnChanged = func(s string) {
 		if s == "Custom" {
-			customMsEntry.Enable()
+			customMsEntry.Show()
 		} else {
-			customMsEntry.Disable()
+			customMsEntry.Hide()
 		}
 	}
 
@@ -924,7 +924,7 @@ func main() {
 		widget.NewSeparator(),
 		widget.NewLabelWithStyle("Typing Speed", fyne.TextAlignLeading, fyne.TextStyle{Bold: true}),
 		speedSelect,
-		customMsEntry,
+		customMsEntry, // hidden unless Custom is selected
 	)
 
 	header := container.NewBorder(nil, nil, left, right, nil)


### PR DESCRIPTION
- New speed dropdown: 
  - Default (no delay)
  - Medium (50 ms)
  - Slow (100 ms)
  - Super Slow (250 MS)
  - Custom
- Custom delay field shown only when Custom is selected
- Applied to “Type” and “Type Clipboard”
- Keeps keyboard layout selector and foreground window logic unchanged